### PR TITLE
Refactor CORS configuration to use externalized allowed origins property

### DIFF
--- a/belatro-backend/src/main/java/backend/belatro/configs/CorsConfig.java
+++ b/belatro-backend/src/main/java/backend/belatro/configs/CorsConfig.java
@@ -1,5 +1,6 @@
 package backend.belatro.configs;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,17 +8,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    @Value("${cors.allowedOrigins}") String originsCsv;
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
 
-                .allowedOrigins(
-                        "http://localhost:3000", //create-react-app
-                        "http://localhost:5173", // Vite React
-                        "http://localhost:19006",
-                        "http://localhost:63342",// common port for React Native with Expo
-                        "http://localhost:9000" //MinIO
-                )
+                .allowedOriginPatterns(originsCsv.split("\\s*,\\s*"))
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/belatro-backend/src/main/resources/application.properties
+++ b/belatro-backend/src/main/resources/application.properties
@@ -6,8 +6,8 @@ spring.data.redis.ssl.enabled=false
 spring.data.redis.username=${REDIS_USER}
 spring.data.redis.password=${REDIS_PASS}
 
-
-
+cors.allowedOrigins=${CORS_ALLOWEDORIGINS:http://localhost:3000,http://127.0.0.1:*}
+logging.level.org.springframework.security=DEBUG
 jwt.secret=${JWT_SECRET}
 jwt.expiration=120
 


### PR DESCRIPTION
- Replaced hardcoded CORS allowed origins with values from `cors.allowedOrigins` property.
- Updated `application.properties` to include `cors.allowedOrigins` with default values.